### PR TITLE
Fix null references in Pack operation

### DIFF
--- a/CP77.CR2W/Archive/Archive.cs
+++ b/CP77.CR2W/Archive/Archive.cs
@@ -133,10 +133,10 @@ namespace CP77.CR2W.Archive
             #region buffers pre-locate
 
             // TODO: fix that for textures (pack from .tga and not .buffer)? probably in an intermediary step
-            var buffersDict = new ConcurrentDictionary<ulong, List<FileInfo>>();
+            var buffersDict = new Dictionary<ulong, List<FileInfo>>();
             var allfiles = infolder.GetFiles("*", SearchOption.AllDirectories);
             var buffersList = allfiles.Where(_ => _.Extension == ".buffer");
-            Parallel.ForEach(buffersList, fileInfo =>
+            foreach (var fileInfo in buffersList)
             {
                 // buffer path e.g. stand__rh_hold_tray__serve_milkshakes__01.scenerid.7.buffer
                 // removes 7 characters (".buffer") and then removes the extension (".7")
@@ -146,9 +146,9 @@ namespace CP77.CR2W.Archive
 
                 // add buffer
                 if (!buffersDict.ContainsKey(hash))
-                    buffersDict.AddOrUpdate(hash, new List<FileInfo>(), (arg1, o) => new List<FileInfo>());
+                    buffersDict.Add(hash, new List<FileInfo>());
                 buffersDict[hash].Add(fileInfo);
-            });
+            }
 
             #endregion
 


### PR DESCRIPTION
List object inside buffersDict was not thread-safe, resulting in occasional null value insertion & failed lookup. Removed parallel execution as a quick fix.