### PR TITLE
FNV 1a 64-bit hash algorithm optimizations

### DIFF
--- a/CP77.Common/Tools/FNV1A/FNV1A64HashAlgorithm.cs
+++ b/CP77.Common/Tools/FNV1A/FNV1A64HashAlgorithm.cs
@@ -1,12 +1,13 @@
 ﻿using System;
+using System.Buffers;
 using System.Security.Cryptography;
 using System.Text;
 
-/// <summary>
-/// Hash algorithm, Fowler–Noll–Vo
-/// </summary>
 namespace CP77.Common.Tools.FNV1A
 {
+    /// <summary>
+    /// Hash algorithm, Fowler–Noll–Vo
+    /// </summary>
     public sealed class FNV1A64HashAlgorithm : HashAlgorithm
     {
         private const ulong FnvHashPrime = 0x00000100000001B3;
@@ -15,23 +16,13 @@ namespace CP77.Common.Tools.FNV1A
         private ulong fnvhash;
         private Encoding encoding;
 
-        public ulong HashUInt64
-        {
-            get
-            {
-                if (fnvhash == FnvHashInitial)
-                {
-                    return 0;
-                }
-                return fnvhash;
-            }
-        }
+        public ulong HashUInt64 => fnvhash == FnvHashInitial ? 0 : fnvhash;
 
         public FNV1A64HashAlgorithm()
             : this(Encoding.ASCII)
         {
-
         }
+
         public FNV1A64HashAlgorithm(Encoding encoding)
         {
             this.Initialize();
@@ -48,41 +39,29 @@ namespace CP77.Common.Tools.FNV1A
         {
             AppendString(value, false);
         }
+
         public void AppendString(string value, bool nullEnded)
         {
-            if (String.IsNullOrEmpty(value))
+            if (string.IsNullOrEmpty(value))
                 return;
 
-            var buffer = new char[nullEnded ? value.Length + 1 : value.Length];
-            value.CopyTo(0, buffer, 0, value.Length);
+            var length = encoding.GetMaxByteCount(nullEnded ? value.Length + 1 : value.Length);
+            var buffer = ArrayPool<byte>.Shared.Rent(length);
+            try
+            {
+                var encodedLength = encoding.GetBytes(value.AsSpan(), buffer.AsSpan());
+                if (nullEnded)
+                {
+                    buffer[encodedLength] = 0;
+                    encodedLength++;
+                }
 
-            var data = encoding.GetBytes(buffer);
-
-            HashCore(data, 0, data.Length);
-        }
-
-        public static ulong HashString(string value)
-        {
-            return HashString(value, Encoding.ASCII, false);
-        }
-        public static ulong HashString(string value, Encoding encoding)
-        {
-            return HashString(value, encoding, false);
-        }
-        public static ulong HashString(string value, Encoding encoding, bool nullEnded)
-        {
-            if (String.IsNullOrEmpty(value))
-                return 0;
-
-            var buffer = new char[nullEnded ? value.Length + 1 : value.Length];
-            value.CopyTo(0, buffer, 0, value.Length);
-
-            var fnv1a = new FNV1A64HashAlgorithm();
-            var data = encoding.GetBytes(buffer);
-
-            fnv1a.HashCore(data, 0, data.Length);
-
-            return fnv1a.fnvhash;
+                HashCore(buffer, 0, encodedLength);
+            }
+            finally
+            {
+                ArrayPool<byte>.Shared.Return(buffer);
+            }
         }
 
         protected override void HashCore(byte[] array, int ibStart, int cbSize)
@@ -95,15 +74,14 @@ namespace CP77.Common.Tools.FNV1A
             var ibEnd = ibStart + cbSize;
             if (ibEnd > array.Length)
             {
-                throw new IndexOutOfRangeException(); 
+                throw new IndexOutOfRangeException();
             }
 
             unchecked
             {
                 for (int i = ibStart; i < ibEnd; i++)
                 {
-                    this.fnvhash ^= array[i];
-                    this.fnvhash *= FnvHashPrime;
+                    this.fnvhash = (this.fnvhash ^ array[i]) * FnvHashPrime;
                 }
             }
         }
@@ -111,6 +89,61 @@ namespace CP77.Common.Tools.FNV1A
         protected override byte[] HashFinal()
         {
             return BitConverter.GetBytes(this.HashUInt64);
+        }
+
+
+        public static ulong HashString(string value)
+        {
+            return HashString(value, Encoding.ASCII, false);
+        }
+
+        public static ulong HashString(string value, Encoding encoding, bool nullEnded = false)
+        {
+            var length = encoding.GetMaxByteCount(nullEnded ? value.Length + 1 : value.Length);
+            var buffer = ArrayPool<byte>.Shared.Rent(length);
+            try
+            {
+                var encodedLength = encoding.GetBytes(value.AsSpan(), buffer.AsSpan());
+                if (nullEnded)
+                {
+                    buffer[encodedLength] = 0;
+                    encodedLength++;
+                }
+
+                return HashReadOnlySpan(new ReadOnlySpan<byte>(buffer, 0, encodedLength));
+            }
+            finally
+            {
+                ArrayPool<byte>.Shared.Return(buffer);
+            }
+        }
+
+        public static ulong HashReadOnlySpan(ReadOnlySpan<char> source)
+        {
+            var hash = FnvHashInitial;
+            foreach (var b in source)
+            {
+                unchecked
+                {
+                    hash = (hash ^ b) * FnvHashPrime;
+                }
+            }
+
+            return hash;
+        }
+
+        public static ulong HashReadOnlySpan(ReadOnlySpan<byte> source)
+        {
+            var hash = FnvHashInitial;
+            foreach (var b in source)
+            {
+                unchecked
+                {
+                    hash = (hash ^ b) * FnvHashPrime;
+                }
+            }
+
+            return hash;
         }
     }
 }

--- a/CP77.MSTests/FNV1A64Tests.cs
+++ b/CP77.MSTests/FNV1A64Tests.cs
@@ -1,0 +1,108 @@
+using System;
+using System.Text;
+using CP77.Common.Tools.FNV1A;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace CP77.MSTests
+{
+    [TestClass]
+    public class FNV1A64Tests
+    {
+        [TestMethod]
+        [DataRow("", 0xcbf29ce484222325UL)]
+        [DataRow("a", 0xaf63dc4c8601ec8cUL)]
+        [DataRow("foobar", 0x85944171f73967e8UL)]
+        [DataRow("\0", 0xaf63bd4c8601b7dfUL)]
+        [DataRow("a\0", 0x089be207b544f1e4UL)]
+        [DataRow("foobar\0", 0x34531ca7168b8f38UL)]
+        [DataRow("hi", 0x08ba5f07b55ec3daUL)]
+        [DataRow("hi\0", 0x337354193006cb6eUL)]
+        [DataRow("hello", 0xa430d84680aabd0bUL)]
+        [DataRow("hello\0", 0xa9bc8acca21f39b1UL)]
+        [DataRow("127.0.0.1", 0xaabafe7104d914beUL)]
+        [DataRow("127.0.0.1\0", 0xf4d3180b3cde3edaUL)]
+        [DataRow("127.0.0.2", 0xaabafd7104d9130bUL)]
+        [DataRow("127.0.0.2\0", 0xf4cfb20b3cdb5bb1UL)]
+        [DataRow("127.0.0.3", 0xaabafc7104d91158UL)]
+        [DataRow("127.0.0.3\0", 0xf4cc4c0b3cd87888UL)]
+        [DataRow("feedfacedeadbeef", 0xcac54572bb1a6fc8UL)]
+        [DataRow("feedfacedeadbeef\0", 0xa7a4c9f3edebf0d8UL)]
+        [DataRow("line 1\nline 2\nline 3", 0x7829851fac17b143UL)]
+        public void TestFNV1a64(string test, ulong result)
+        {
+            // Assert.AreEqual(FNV1A64HashAlgorithm.HashString(test), result);
+            Assert.AreEqual(FNV1A64HashAlgorithm.HashString(test), result);
+        }
+
+        [TestMethod]
+        [DataRow("", 0xaf63bd4c8601b7dfUL)]
+        [DataRow("a", 0x089be207b544f1e4UL)]
+        [DataRow("hi", 0x337354193006cb6eUL)]
+        [DataRow("hello", 0xa9bc8acca21f39b1UL)]
+        [DataRow("foobar", 0x34531ca7168b8f38UL)]
+        [DataRow("feedfacedeadbeef", 0xa7a4c9f3edebf0d8UL)]
+        public void TestFNV1a64_NullEnded(string test, ulong result)
+        {
+            Assert.AreEqual(FNV1A64HashAlgorithm.HashString(test, Encoding.ASCII, true), result);
+        }
+
+        [TestMethod]
+        [DataRow(new byte[] {0xff, 0x00, 0x00, 0x01}, 0x6961196491cc682dUL)]
+        [DataRow(new byte[] {0x01, 0x00, 0x00, 0xff}, 0xad2bb1774799dfe9UL)]
+        [DataRow(new byte[] {0xff, 0x00, 0x00, 0x02}, 0x6961166491cc6314UL)]
+        [DataRow(new byte[] {0x02, 0x00, 0x00, 0xff}, 0x8d1bb3904a3b1236UL)]
+        [DataRow(new byte[] {0xff, 0x00, 0x00, 0x03}, 0x6961176491cc64c7UL)]
+        [DataRow(new byte[] {0x03, 0x00, 0x00, 0xff}, 0xed205d87f40434c7UL)]
+        [DataRow(new byte[] {0xff, 0x00, 0x00, 0x04}, 0x6961146491cc5faeUL)]
+        [DataRow(new byte[] {0x04, 0x00, 0x00, 0xff}, 0xcd3baf5e44f8ad9cUL)]
+        [DataRow(new byte[] {0x40, 0x51, 0x4e, 0x44}, 0xe3b36596127cd6d8UL)]
+        [DataRow(new byte[] {0x44, 0x4e, 0x51, 0x40}, 0xf77f1072c8e8a646UL)]
+        [DataRow(new byte[] {0x40, 0x51, 0x4e, 0x4a}, 0xe3b36396127cd372UL)]
+        [DataRow(new byte[] {0x4a, 0x4e, 0x51, 0x40}, 0x6067dce9932ad458UL)]
+        [DataRow(new byte[] {0x40, 0x51, 0x4e, 0x54}, 0xe3b37596127cf208UL)]
+        [DataRow(new byte[] {0x54, 0x4e, 0x51, 0x40}, 0x4b7b10fa9fe83936UL)]
+        public void TestFNV1a64_ByteSpan(byte[] test, ulong result)
+        {
+            Assert.AreEqual(FNV1A64HashAlgorithm.HashReadOnlySpan(test), result);
+        }       
+        
+        [TestMethod]
+        [DataRow("\xff\x00\x00\x01", 0x6961196491cc682dUL)]
+        [DataRow("\x01\x00\x00\xff", 0xad2bb1774799dfe9UL)]
+        [DataRow("\xff\x00\x00\x02", 0x6961166491cc6314UL)]
+        [DataRow("\x02\x00\x00\xff", 0x8d1bb3904a3b1236UL)]
+        [DataRow("\xff\x00\x00\x03", 0x6961176491cc64c7UL)]
+        [DataRow("\x03\x00\x00\xff", 0xed205d87f40434c7UL)]
+        [DataRow("\xff\x00\x00\x04", 0x6961146491cc5faeUL)]
+        [DataRow("\x04\x00\x00\xff", 0xcd3baf5e44f8ad9cUL)]
+        [DataRow("\x40\x51\x4e\x44", 0xe3b36596127cd6d8UL)]
+        [DataRow("\x44\x4e\x51\x40", 0xf77f1072c8e8a646UL)]
+        [DataRow("\x40\x51\x4e\x4a", 0xe3b36396127cd372UL)]
+        [DataRow("\x4a\x4e\x51\x40", 0x6067dce9932ad458UL)]
+        [DataRow("\x40\x51\x4e\x54", 0xe3b37596127cf208UL)]
+        [DataRow("\x54\x4e\x51\x40", 0x4b7b10fa9fe83936UL)]
+        [DataRow("", 0xcbf29ce484222325UL)]
+        [DataRow("a", 0xaf63dc4c8601ec8cUL)]
+        [DataRow("foobar", 0x85944171f73967e8UL)]
+        [DataRow("\0", 0xaf63bd4c8601b7dfUL)]
+        [DataRow("a\0", 0x089be207b544f1e4UL)]
+        [DataRow("foobar\0", 0x34531ca7168b8f38UL)]
+        [DataRow("hi", 0x08ba5f07b55ec3daUL)]
+        [DataRow("hi\0", 0x337354193006cb6eUL)]
+        [DataRow("hello", 0xa430d84680aabd0bUL)]
+        [DataRow("hello\0", 0xa9bc8acca21f39b1UL)]
+        [DataRow("127.0.0.1", 0xaabafe7104d914beUL)]
+        [DataRow("127.0.0.1\0", 0xf4d3180b3cde3edaUL)]
+        [DataRow("127.0.0.2", 0xaabafd7104d9130bUL)]
+        [DataRow("127.0.0.2\0", 0xf4cfb20b3cdb5bb1UL)]
+        [DataRow("127.0.0.3", 0xaabafc7104d91158UL)]
+        [DataRow("127.0.0.3\0", 0xf4cc4c0b3cd87888UL)]
+        [DataRow("feedfacedeadbeef", 0xcac54572bb1a6fc8UL)]
+        [DataRow("feedfacedeadbeef\0", 0xa7a4c9f3edebf0d8UL)]
+        [DataRow("line 1\nline 2\nline 3", 0x7829851fac17b143UL)]
+        public void TestFNV1a64_CharSpan(string test, ulong result)
+        {
+            Assert.AreEqual(FNV1A64HashAlgorithm.HashReadOnlySpan(test.AsSpan()), result);
+        }
+    }
+}


### PR DESCRIPTION
FNV is used in some hot paths such as loading hashes (over 1.5 million times per app start).
This PR improves FNV implementations in two ways:
- Removed allocations by reusing arrays from pool
- Added simplified Span-based versions of algorithm without string re-encoding (hashing is mostly used for filenames with ascii subset)

Benchmark: hashing 1.5m items from `archivehashes.zip`
``` ini

BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19042
Intel Core i7-8750H CPU 2.20GHz (Coffee Lake), 1 CPU, 12 logical and 6 physical cores
.NET Core SDK=5.0.101
  [Host]   : .NET Core 5.0.1 (CoreCLR 5.0.120.57516, CoreFX 5.0.120.57516), X64 RyuJIT
  ShortRun : .NET Core 5.0.1 (CoreCLR 5.0.120.57516, CoreFX 5.0.120.57516), X64 RyuJIT

Job=ShortRun  IterationCount=3  LaunchCount=1  
WarmupCount=3  

```
|                                          Method |     Mean |    Error |  StdDev | Ratio |       Gen 0 | Gen 1 | Gen 2 |   Allocated |
|------------------------------------------------ |---------:|---------:|--------:|------:|------------:|------:|------:|------------:|
|                         &#39;Original hashing impl&#39; | 446.6 ms | 13.94 ms | 0.76 ms |  1.00 | 105000.0000 |     - |     - | 498528288 B |
|                   &#39;This PR string hashing impl&#39; | 181.8 ms | 38.82 ms | 2.13 ms |  0.41 |           - |     - |     - |       304 B |
| &#39;This PR span-based (no encoding) hashing impl&#39; | 110.4 ms | 12.12 ms | 0.66 ms |  0.25 |           - |     - |     - |       202 B |
