### PR TITLE
Streaming from zip-archive with hashes without extracting.

### DIFF
--- a/CP77.CR2W/Resources/AppSettingsService.cs
+++ b/CP77.CR2W/Resources/AppSettingsService.cs
@@ -9,7 +9,7 @@ namespace CP77.CR2W.Resources
         public string ResourcesPath => Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Resources");
 
         public string ETagPath => Path.Combine(ResourcesPath, "archivehashes-etag.txt");
-        public string ArchiveHashesPath => Path.Combine(ResourcesPath, "archivehashes.txt");
+        public string ArchiveHashesPath => "archivehashes.txt";
         public string LooseHashesPath => Path.Combine(ResourcesPath, "loosehashes.txt");
         public string ArchiveHashesZipPath => Path.Combine(ResourcesPath, "archivehashes.zip");
     }

--- a/CP77.Common/Services/HashService.cs
+++ b/CP77.Common/Services/HashService.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Buffers;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -7,6 +8,7 @@ using System.IO.Compression;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
+using System.Text;
 using System.Threading.Tasks;
 using Catel;
 using Catel.IoC;
@@ -16,16 +18,7 @@ namespace CP77.Common.Services
 {
     public class HashService : IHashService
     {
-        private Dictionary<ulong, string> _hashdict = new();
-        public Dictionary<ulong, string> Hashdict
-        {
-            get
-            {
-                return _hashdict;
-                
-            }
-            set => _hashdict = value;
-        }
+        public Dictionary<ulong, string> Hashdict { get; set; } = new();
 
         private static readonly ILoggerService Logger = ServiceLocator.Default.ResolveType<ILoggerService>();
         private static readonly IAppSettingsService Appsettings = ServiceLocator.Default.ResolveType<IAppSettingsService>();
@@ -34,10 +27,7 @@ namespace CP77.Common.Services
 
         //private const string ResourceUrl = "https://nyxmods.com/cp77/files/archivehashes.csv";
         private const string ResourceUrl = "https://graphicscore.dev/cyberpunk/cyberbot/data/loosehashes.txt";
-        
-        
 
-        
 
         public async Task<bool> RefreshAsync()
         {
@@ -66,7 +56,6 @@ namespace CP77.Common.Services
 
             try
             {
-                
                 var response = await _client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead);
                 if (response.StatusCode == HttpStatusCode.NotModified)
                 {
@@ -130,7 +119,7 @@ namespace CP77.Common.Services
         private string GetLastEtag()
         {
             if (!File.Exists(Appsettings.ETagPath)) return null;
-            
+
             var lines = File.ReadLines(Appsettings.ETagPath)
                 .ToList();
 
@@ -146,51 +135,35 @@ namespace CP77.Common.Services
 
             Stopwatch watch = new();
             watch.Restart();
-
-            var hashDictionary = new ConcurrentDictionary<ulong, string>();
-
-            // TODO: proper update handling
-            try
+            
+            Hashdict.EnsureCapacity(1_500_000);
+            
+            using (var archive = ZipFile.Open(Appsettings.ArchiveHashesZipPath, ZipArchiveMode.Read, Encoding.UTF8))
             {
-                File.Delete(Appsettings.ArchiveHashesPath);
-            }
-            catch (Exception)
-            {
-                Logger.LogString($"Could not delete file {Appsettings.ArchiveHashesPath}.", Logtype.Error);
-            }
-
-            ZipFile.ExtractToDirectory(Appsettings.ArchiveHashesZipPath, Appsettings.ResourcesPath);
-            if (File.Exists(Appsettings.ArchiveHashesPath))
-                Parallel.ForEach(File.ReadLines(Appsettings.ArchiveHashesPath), line =>
+                var zipArchiveEntry = archive.GetEntry(Appsettings.ArchiveHashesPath);
+                if (zipArchiveEntry != null)
                 {
-                    // check line
-                    if (line.Contains(','))
-                        line = line.Split(',', StringSplitOptions.RemoveEmptyEntries).First();
-                    if (string.IsNullOrEmpty(line))
-                        return;
-                    ulong hash = FNV1A64HashAlgorithm.HashString(line);
-                    hashDictionary.AddOrUpdate(hash, line, (key, val) => val);
-                });
+                    using var stream = zipArchiveEntry.Open();
+                    AddHashesFromStream(Hashdict, stream);
+                }
+            }
 
             if (File.Exists(Appsettings.LooseHashesPath))
-                Parallel.ForEach(File.ReadLines(Appsettings.LooseHashesPath), line =>
-                {
-                    // check line
-                    if (line.Contains(','))
-                        line = line.Split(',', StringSplitOptions.RemoveEmptyEntries).First();
-                    if (string.IsNullOrEmpty(line))
-                        return;
-                    ulong hash = FNV1A64HashAlgorithm.HashString(line);
-                    hashDictionary.AddOrUpdate(hash, line, (key, val) => val);
-                });
-
-            Hashdict = hashDictionary.ToDictionary(
-                entry => entry.Key,
-                entry => entry.Value);
+                AddHashesFromStream(Hashdict, File.OpenRead(Appsettings.LooseHashesPath));
 
             watch.Stop();
 
-            Logger.LogString($"Loaded {hashDictionary.Count} hashes in {watch.ElapsedMilliseconds}ms.", Logtype.Success);
+            Logger.LogString($"Loaded {Hashdict.Count} hashes in {watch.ElapsedMilliseconds}ms.", Logtype.Success);
+        }
+
+        private static void AddHashesFromStream(IDictionary<ulong, string> dictionary, Stream stream)
+        {
+            string line;
+            using var sr = new StreamReader(stream, Encoding.UTF8);
+            while ((line = sr.ReadLine()) != null)
+            {
+                dictionary[FNV1A64HashAlgorithm.HashString(line)] = line;
+            }
         }
     }
 }


### PR DESCRIPTION
This PR improves loading time and disk space by removing extraction of `archivehashes.zip`.
`archivehashes.txt` will be streamed from memory to to construct dictionary with hashes.
It will save user a ~100mb of disk space.
Also, `Parallel.For` is removed because it is much faster just xor and multiply over a string (FNV hash) than thread synchronization.

### Benchmark

Load `archivehashes.zip` and construct `Dictionary<ulong,string>`
``` ini

BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19042
Intel Core i7-8750H CPU 2.20GHz (Coffee Lake), 1 CPU, 12 logical and 6 physical cores
.NET Core SDK=5.0.101
  [Host]    : .NET Core 5.0.1 (CoreCLR 5.0.120.57516, CoreFX 5.0.120.57516), X64 RyuJIT
  MediumRun : .NET Core 5.0.1 (CoreCLR 5.0.120.57516, CoreFX 5.0.120.57516), X64 RyuJIT

Job=MediumRun  IterationCount=15  LaunchCount=2  
WarmupCount=10  

```
|                                             Method |    Mean |    Error |   StdDev | Ratio | RatioSD |       Gen 0 |      Gen 1 |     Gen 2 | Allocated |
|--------------------------------------------------- |--------:|---------:|---------:|------:|--------:|------------:|-----------:|----------:|----------:|
|               &#39;Extract zip and parallel ReadLines&#39; | 3.173 s | 0.0807 s | 0.1208 s |  1.00 |    0.00 | 159000.0000 | 47000.0000 | 1000.0000 | 997.22 MB |
|                       &#39;Stream right from zip-file&#39; | 1.829 s | 0.0244 s | 0.0334 s |  0.58 |    0.03 | 128000.0000 | 36000.0000 | 1000.0000 | 910.06 MB |
| &#39;Stream right from zip-file with no-alloc hashing from #49 &#39; | 1.290 s | 0.0162 s | 0.0237 s |  0.41 |    0.02 |  48000.0000 | 17000.0000 | 1000.0000 | 434.63 MB |


### Future consideration
Move to some file-based embedded databases like [LiteDB](https://github.com/mbdavid/LiteDB), SQLite or even some KV-store like [microsoft/FASTER](https://github.com/microsoft/FASTER).
There is no reason to spend ~300 Mb of RAM (250 Mb of 1.5kk UTF-16 strings and 90 Mb of dictionary buckets) each time to extract few files. 