### PR TITLE
Hashlist extraction

### DIFF
--- a/CP77Tools/Commands/ArchiveCommand.cs
+++ b/CP77Tools/Commands/ArchiveCommand.cs
@@ -22,9 +22,9 @@ namespace CP77Tools.Commands
             AddOption(new Option<bool>(new[] {"--uncook", "-u"}, "Uncooks textures from archive."));
             AddOption(new Option<EUncookExtension>(new[] {"--uext"}, "Uncook extension (tga, bmp, jpg, png, dds). Default is tga."));
             AddOption(new Option<bool>(new[] { "--flip", "-f" }, "Flips textures vertically"));
-            AddOption(new Option<ulong>(new[] {"--hash"}, "Extract single file with given hash."));
+            AddOption(new Option<string>(new[] {"--hash"}, "Extract single file with given hash. If a path is supplied it extracts all hashes from that."));
             
-            Handler = CommandHandler.Create<string[], string, bool, bool, bool, bool, EUncookExtension, bool, ulong, string, string>(ConsoleFunctions.ArchiveTask);
+            Handler = CommandHandler.Create<string[], string, bool, bool, bool, bool, EUncookExtension, bool, string, string, string>(ConsoleFunctions.ArchiveTask);
         }
     }
 }


### PR DESCRIPTION
Implemented #58 
As requested by @Ekey
![image](https://media.tenor.com/images/e6b66bab9f4823669022390011284d91/tenor.gif)
Example:
```bash
CP77Tools.exe archive -e -p "D:\SteamLibrary\steamapps\common\Cyberpunk 2077\archive\pc\content\basegame_1_engine.archive" --hash "D:\cyberpunkmodding\missinghashes.txt"
```
